### PR TITLE
Fix "Continue Reading" href

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
 				<p>
 					{{ article.summary }}
 				</p>
-				<a class="read-more" href="{{ article.url }}">Continue reading »</a>
+				<a class="read-more" href="{{ SITEURL }}/{{ article.url }}">Continue reading »</a>
 			</div>
 		{% endfor %}
 	</div>


### PR DESCRIPTION
Without the `{{ SITEURL }}/` works fine with the default category and tags setup, but when those URL structures change, then this URL becomes invalid.

```
CATEGORY_URL = "category/{slug}"
CATEGORY_SAVE_AS = "category/{slug}/index.html"
TAG_URL = "tag/{slug}"
TAG_SAVE_AS = "tag/{slug}/index.html"
```